### PR TITLE
Use correct way to do Library Configuration

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -1,4 +1,0 @@
-use Mix.Config
-
-config :ex_postmark,
-  rest_adapter: :hackney

--- a/lib/ex_postmark/adapters/postmark.ex
+++ b/lib/ex_postmark/adapters/postmark.ex
@@ -104,7 +104,7 @@ defmodule ExPostmark.Adapters.Postmark do
     do: rest_adapter().post(url(), headers, params, [:with_body])
 
   defp rest_adapter(),
-    do: Application.get_env(:ex_postmark, :rest_adapter)
+    do: Application.get_env(:ex_postmark, :rest_adapter, :hackney)
 
   defp url(), do: [@base_url, @api_endpoint]
 end

--- a/test/integration/postmark_test.exs
+++ b/test/integration/postmark_test.exs
@@ -24,8 +24,6 @@ defmodule ExPostmark.Integration.TestPostmark do
     adapter:        ExPostmark.Adapters.Postmark
   )
 
-  Application.put_env(:ex_postmark, :rest_adapter, :hackney)
-
   defmodule PostmarkMailer do
     use ExPostmark.Mailer, otp_app: :ex_postmark
   end


### PR DESCRIPTION
The configuration of a library is not read. Instead of providing a config with the lib, this PR makes use of the default argument of the `Application.get_env` function.