### PR TITLE
Only need to provide Env Vars for Integration Tests

### DIFF
--- a/test/integration/postmark_test.exs
+++ b/test/integration/postmark_test.exs
@@ -10,13 +10,17 @@ defmodule ExPostmark.Integration.TestPostmark do
   @postmark_email_from  System.get_env("POSTMARK_EMAIL_FROM")
   @postmark_email_to    System.get_env("POSTMARK_EMAIL_TO")
 
-  @email Email.new(
-    subject:        "Hello from TravisCI",
-    from:           @postmark_email_from,
-    to:             @postmark_email_to,
-    template_id:    @postmark_template_id,
-    template_model: %{name: "TravisCI", product_name: "ExPostmark"}
-  )
+  setup do
+    email = Email.new(
+      subject:        "Hello from TravisCI",
+      from:           @postmark_email_from,
+      to:             @postmark_email_to,
+      template_id:    @postmark_template_id,
+      template_model: %{name: "TravisCI", product_name: "ExPostmark"}
+    )
+
+    {:ok, email: email}
+  end
 
   Application.put_env(
     :ex_postmark,   ExPostmark.Integration.TestPostmark.PostmarkMailer,
@@ -28,7 +32,7 @@ defmodule ExPostmark.Integration.TestPostmark do
     use ExPostmark.Mailer, otp_app: :ex_postmark
   end
 
-  test "should deliver a template email using Postmark service" do
-    assert {:ok, %{id: _id}} = PostmarkMailer.deliver(@email)
+  test "should deliver a template email using Postmark service", %{email: email} do
+    assert {:ok, %{id: _id}} = PostmarkMailer.deliver(email)
   end
 end


### PR DESCRIPTION
Prevent this issue:

```
Excluding tags: [:integration]

.....................** (ArgumentError) The recipient `nil` is invalid.
Recipients must be a string representing an email address
like `foo.bar@example.com` or a two-element tuple `{name, address}`,
where name and address are strings.

    (ex_postmark) lib/ex_postmark/formatter.ex:19: ExPostmark.Formatter.raise_invalid_recipient/1
    (ex_postmark) lib/ex_postmark/email.ex:200: ExPostmark.Email.from/2
    (elixir) lib/enum.ex:1755: Enum."-reduce/3-lists^foldl/2-0-"/3
    test/integration/postmark_test.exs:13: (module)
    (stdlib) erl_eval.erl:670: :erl_eval.do_apply/6
    (elixir) lib/code.ex:370: Code.require_file/2
```